### PR TITLE
設定ファイルが開けない不具合を修正

### DIFF
--- a/cmemo_desktop.py
+++ b/cmemo_desktop.py
@@ -141,7 +141,7 @@ class Desktop(ckit.Window):
         fullpath = os.path.abspath(self.config_filename)
     
         if callable(self.editor):
-            main_window.editor(fullpath)
+            self.editor(fullpath)
         else:
             pyauto.shellExecute( None, self.editor, '"%s"' % fullpath, "" )
 


### PR DESCRIPTION
desktop.editorにcallableオブジェクトを設定すると設定ファイルが開けなくなっていたので修正しました。
